### PR TITLE
remove deutsch luxemburgische Hoheitsgebiet.

### DIFF
--- a/ags/2021.csv
+++ b/ags/2021.csv
@@ -8583,7 +8583,6 @@ ags,description
 10042115,Perl
 10042116,"Wadern, Stadt"
 10042117,Weiskirchen
-10042999,Deutsch-luxemburgisches Hoheitsgebiet
 10043000,"Neunkirchen, (Landkreis)"
 10043111,Eppelborn
 10043112,Illingen


### PR DESCRIPTION
This is not an area we will model.  It appeared in our list because during the years since 2018 Perl has given up some area to it. So https://github.com/GermanZero-de/localzero-generator-core/blob/0ce881c7c0c486ff8ed44b08058aa707f5c0ce87/exploration-and-data-generation/ags-update/main.py#L213 added it to the master list.